### PR TITLE
Support SMTP servers that do not allow authentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,15 +17,18 @@ var Resource       = require('deployd/lib/resource'),
 function Email( options ) {
 
   Resource.apply( this, arguments );
-
+  var authParams=null;
+  if(this.config.username!==''){
+    authParams={
+      user: this.config.username,
+      pass: this.config.password
+    };
+  }
   this.transport = nodemailer.createTransport('SMTP', {
     host : this.config.host || 'localhost',
     port : parseInt(this.config.port, 10) || 25,
     secureConnection : this.config.ssl,
-    auth : {
-      user: this.config.username,
-      pass: this.config.password
-    }
+    auth : authParams
   });
 
 }


### PR DESCRIPTION
If you are not passed a username in your config, don't pass an authentication parameter to NodeMailer. This is useful for SMTP configurations that do not utilize (or permit) authentication (For example: DevNullSMTP).
