### PR TITLE
Add `--save` option to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is built on Andris Reinmans [Nodemailer](https://github.com/andris9/Nodemai
 
 ## Installation
 
-`$ npm install dpd-email`
+`$ npm install --save dpd-email`
 
 See [Installing Modules](http://docs.deployd.com/docs/using-modules/) for details.
 


### PR DESCRIPTION
The 'email' collection doesn't show up in the dashboard unless `dpd-email` is present in `package.json` (took me a while to figure this out!)