### PR TITLE
Allow user to store password in environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If checked, use SSL to communicate with your SMTP provider.
 The SMTP username for your app.
 
 **password**  
-The SMTP password for your app.  
+The SMTP password for your app. Leave this blank to use the DPD\_EMAIL\_SMTP\_PASSWORD environment variable.  
 
 ### Optional settings:
 

--- a/index.js
+++ b/index.js
@@ -15,15 +15,15 @@ var Resource       = require('deployd/lib/resource'),
 function Email( ) {
 
   Resource.apply( this, arguments );
-  
+
   var authParams=null;
   if(this.config.username!==''){
     authParams={
       user: this.config.username,
-      pass: this.config.password
+      pass: this.config.password || process.env.DPD_EMAIL_SMTP_PASSWORD
     };
   }
-  
+
   this.transport = nodemailer.createTransport(smtp({
     host : this.config.host || 'localhost',
     port : parseInt(this.config.port, 10) || 25,
@@ -60,7 +60,7 @@ Email.basicDashboard = {
   }, {
     name        : 'password',
     type        : 'text',
-    description : 'SMTP password'
+    description : 'SMTP password. Leave this blank to use the DPD_EMAIL_SMTP_PASSWORD environment variable'
   }, {
     name        : 'defaultFromAddress',
     type        : 'text',


### PR DESCRIPTION
This is a potential fix for #16 - it picks up the password from `DPD_EMAIL_SMTP_PASSWORD` if it's blank in the configuration.

Let me know what you think! 